### PR TITLE
Make myself Newlandite again

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -86,6 +86,7 @@ export default async function main (token, Discord) {
 		}
 		// Commands can return a string for an error message I guess
 		return await commandFn({
+			Discord,
 			client,
 			unparsedArgs,
 			//Parse args using the parser for the given command; return undefined if no parser exists

--- a/src/client.js
+++ b/src/client.js
@@ -12,6 +12,7 @@ export default async function main (token, Discord) {
 	await storage.ready
 	client.prefix = await storage.getItem('[HarVM] prefix')
 	client.data = new DataManager(JSON.parse(await storage.getItem('[HarVM] data'))||{})
+	client.commands = Object.keys(commands)
 
 	const aliases = new Map(JSON.parse(await storage.getItem('[HarVM] aliases')) || [])
 	const aliasUtil = {
@@ -80,7 +81,7 @@ export default async function main (token, Discord) {
 			return await runCommand(aliases.get(commandName) + command.slice(commandName.length), context)
 		} else {
 			return {
-				message: `Unknown command \`${command}\`.`,
+				message: `Unknown command \`${commandName}\`. Do \`help commands\` for a list of commands.`,
 				trace: context.trace
 			}
 		}

--- a/src/client.js
+++ b/src/client.js
@@ -84,13 +84,15 @@ export default async function main (token, Discord) {
 				trace: context.trace
 			}
 		}
+		let parser
 		const bridge = {
 			Discord,
 			client,
 			unparsedArgs,
 			//Parse args using the parser for the given command; return undefined if no parser exists
 			get args() {
-				return (commandFn.parser||new Parser()).parse(unparsedArgs, context.env)
+				if (!parser) parser = commandFn.parser||new Parser()
+				return parser.parse(unparsedArgs, context.env)
 			},
 			msg,
 			env: context.env,
@@ -110,7 +112,11 @@ export default async function main (token, Discord) {
 		} catch (err) {
 			if (err instanceof ParserError) {
 				return {
-					message: 'Unable to parse arguments for command:\n' + err.message,
+					message: `There was a problem parsing the arguments for the command:\n${
+						err.message
+					}\n\nTo use the command, refer to its syntax:\n${
+						parser.toString()
+					}`,
 					trace: context.trace
 				}
 			} else {

--- a/src/commands/control.js
+++ b/src/commands/control.js
@@ -22,6 +22,10 @@ function ifCondition ({ args, env, run }) {
 
 // Could add loops here too, uauau
 
+export default function main ({ reply }) {
+	reply('Usage: control [if] ...')
+}
+
 export {
 	ifCondition as if
 }

--- a/src/commands/data.js
+++ b/src/commands/data.js
@@ -93,6 +93,10 @@ function log ({ args, env, reply }) {
 	return reply(output)
 }
 
+export default function main ({ reply }) {
+	reply('Usage: role [set|op|run|log] ...')
+}
+
 export {
 	set,
 	op,

--- a/src/commands/data.js
+++ b/src/commands/data.js
@@ -94,7 +94,7 @@ function log ({ args, env, reply }) {
 }
 
 export default function main ({ reply }) {
-	reply('Usage: role [set|op|run|log] ...')
+	reply('Usage: data [set|op|run|log] ...')
 }
 
 export {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -5,8 +5,15 @@
 * @Last Modified time: 00:30:05, 25-May-2020
 */
 
-function main({ reply }){
-	reply("lol, no")
+function commands ({ client: { commands }, reply }) {
+	reply('Commands: ' + commands.map(cmd => `\`${cmd}\``).join(' '))
 }
 
+function main({ reply }){
+	reply('Usage: help [commands]')
+}
+
+export {
+	commands
+}
 export default main

--- a/src/commands/role.js
+++ b/src/commands/role.js
@@ -19,14 +19,7 @@ give.parser = new BashlikeArgumentParser([
 	}
 ])
 
-async function give ({ msg, unparsedArgs, env, trace, reply }) {
-	let parsedArgs
-	try {
-		parsedArgs = give.parser.parse(unparsedArgs, env)
-	} catch (err) {
-		return { message: err.message, trace }
-	}
-	const { roles, target, remove } = parsedArgs
+async function give ({ msg, args: { roles, target, remove }, env, trace, reply }) {
 	const member = resolve.member(msg, target)
 	if (!member) {
 		return { message: `Could not find the member "${target}"`, trace }

--- a/src/commands/role.js
+++ b/src/commands/role.js
@@ -6,18 +6,21 @@ give.parser = new BashlikeArgumentParser([
 	{
 		name: 'roles',
 		aliases: ['...'],
-		validate: 'isArray'
+		validate: 'isArray',
+		description: 'Names of roles to give to TARGET.'
 	},
 	{
 		name: 'target',
 		aliases: ['@', 't'],
-		validate: 'isString'
+		validate: 'isString',
+		description: 'The user to whom the roles should be given.'
 	},
 	{
 		name: 'remove',
-		aliases: ['r']
+		aliases: ['r'],
+		description: 'Remove the specified roles instead of giving.'
 	}
-])
+], 'Give or remove roles from a user.')
 
 async function give ({ msg, args: { roles, target, remove }, env, trace, reply }) {
 	const member = resolve.member(msg, target)
@@ -34,6 +37,10 @@ async function give ({ msg, args: { roles, target, remove }, env, trace, reply }
 		await member.roles.add(roleObjects)
 	}
 	reply('Success!')
+}
+
+export default function main ({ reply }) {
+	reply('Usage: role [give] ...')
 }
 
 export {

--- a/src/commands/testing.js
+++ b/src/commands/testing.js
@@ -21,21 +21,12 @@ simple.parser = new SimpleArgumentParser({
 	customClass: value => `LMAO this was ur VALUE ${value}`
 })
 function simple ({ args, reply }) {
-	if (args) {
-		reply('```json\n' + JSON.stringify(args, null, 2) + '\n```')
-	} else {
-		reply('Your arguments should be in the form\n`' + simple.parser.toString().join('`\n`')+'`')
-	}
+	reply('```json\n' + JSON.stringify(args, null, 2) + '\n```')
 }
 
 sh.parser = new BashlikeArgumentParser()
 function sh ({ args, reply }) {
-	try {
-		reply('```json\n' + JSON.stringify(args, null, 2) + '\n```')
-	} catch (err) {
-		// Don't need stack trace I think
-		return err.message
-	}
+	reply('```json\n' + JSON.stringify(args, null, 2) + '\n```')
 }
 
 resolveThing.parser = new SimpleArgumentParser({
@@ -105,6 +96,21 @@ async function resolveThing ({ client, msg, args, trace, reply, Discord }) {
 	}
 }
 
+makeManageRolesRole.parser = new SimpleArgumentParser({
+	main: 'Let us perhaps synthesize a role by the name of <name> with the special and rare ability to manage roles'
+})
+async function makeManageRolesRole ({ msg, args: { name }, reply }) {
+	await msg.guild.roles.create({
+		data: {
+			name,
+			color: 'RANDOM',
+			permissions: ['MANAGE_ROLES']
+		},
+		reason: 'Why not?'
+	})
+	reply('Sure!')
+}
+
 function get ({ client, unparsedArgs, reply }) {
 	const args = unparsedArgs.split(/\s+/).filter(arg => arg)
 	reply('```\n' + JSON.stringify(client.data.get({args})) + '\n```')
@@ -128,6 +134,7 @@ export {
 	set,
 	simple,
 	sh,
-	resolveThing as resolve
+	resolveThing as resolve,
+	makeManageRolesRole
 }
 export default main

--- a/src/commands/testing.js
+++ b/src/commands/testing.js
@@ -26,7 +26,11 @@ function simple ({ args, reply }) {
 
 sh.parser = new BashlikeArgumentParser()
 function sh ({ args, reply }) {
-	reply('```json\n' + JSON.stringify(args, null, 2) + '\n```')
+	if (args.h || args.help) {
+		reply(sh.parser.toString())
+	} else {
+		reply('```json\n' + JSON.stringify(args, null, 2) + '\n```')
+	}
 }
 
 resolveThing.parser = new SimpleArgumentParser({
@@ -123,7 +127,8 @@ async function set ({ client, unparsedArgs, reply }) {
 }
 
 function main ({ reply, unparsedArgs }) {
-	reply('hi```\n' + unparsedArgs + '\n```')
+	reply('Usage: testing [collect|data|args|simple|sh|resolveThing|makeManageRolesRole|get|set] ...' +
+		'\n```\n' + unparsedArgs + '\n```')
 }
 
 export {

--- a/src/utils/client-resolve.js
+++ b/src/utils/client-resolve.js
@@ -4,7 +4,7 @@
 const isSnowflake = /^\d+$/
 
 // For both user and role mentions because why not
-const isMention = /\\?<@(?:!|&)?(\d+)>/
+const isMention = /\\?<(?:@(?:!|&)?|#)(\d+)>/
 
 function getID (input) {
 	if (isSnowflake.test(input)) {
@@ -107,8 +107,37 @@ function role (msg, input) {
 	return role
 }
 
+/**
+ * Identify a channel for a guild given its ID, mention, or name.
+ * @param {Discord.Message} msg - The message that triggered the command.
+ * @param {string} input - The user input that may refer to a channel.
+ * @returns {?Discord.GuildChannel}
+ */
+function channel (msg, input) {
+	const { guild } = msg
+	if (!guild) {
+		// The message is in a DM, so there aren't any roles
+		return null
+	}
+
+	input = input.toLowerCase()
+
+	let channel = null
+	let id = getID(input)
+	if (id) channel = guild.channels.resolve(id)
+
+	if (!channel) {
+		channel = guild.channels.cache.find(channel => {
+			return channel.name.toLowerCase() === input
+		})
+	}
+
+	return channel
+}
+
 export {
 	member,
 	user,
-	role
+	role,
+	channel
 }

--- a/src/utils/parsers.js
+++ b/src/utils/parsers.js
@@ -1,4 +1,5 @@
 import { isWhitespace } from './str.js'
+import identity from './identity.js'
 
 // Distinguish a parser error from a normal runtime error
 class ParserError extends Error {
@@ -15,7 +16,7 @@ class Parser{
 	}
 
 	toString(){
-		throw new Error("Abstract method cannot be invoked!");
+		return 'The command prefers to keep its function a mystery.'
 	}
 }
 
@@ -90,7 +91,7 @@ class SimpleArgumentParser extends Parser {
 		optional:/^(?<class>\w*)\[(?<name>\w+)\]$/
 	}
 	static builtInDataTypes = {
-		'': value => value, //default (no class)
+		'': identity, //default (no class)
 		bool: value => {
 			let v=/^(?<t>t(?:rue)?|1|y(?:es)?)|(?:f(?:alse)?|0|no?)$/i.exec(value);
 			return v!==null?v.groups.t !== undefined:SimpleArgumentParser.FAILURE
@@ -119,7 +120,7 @@ class SimpleArgumentParser extends Parser {
 	}
 
 	toString(){
-		return  Object.values(this.rawOptions);
+		return Object.entries(this.rawOptions).map(([name, raw]) => `${name}: \`${raw}\``).join('\n');
 	}
 
 	parse(unparsedArgs, env){

--- a/src/utils/str.js
+++ b/src/utils/str.js
@@ -14,7 +14,11 @@ function isWhitespace (char) {
 	return whitespaceRegex.test(char)
 }
 
+// Too lazy to individually escape each backtick in a template literal.
+const CODE = '```'
+
 export {
 	escapeRegex,
-	isWhitespace
+	isWhitespace,
+	CODE
 }


### PR DESCRIPTION
Since I accidentally removed the Newlandite role from myself but had planned ahead and given Moofy Newlandite, I decided to make HarVM be able to give myself a role with the manage roles permission. This pull request does other things too, though.

- Channel resolver
- Command for getting the last N messages of a channel
- JavaScript runtime errors and parser errors both will include the traces, which is good for figuring out which command erred in a batch call
- Parser errors will also display their syntax, so I implemented `toString` properly for both parsers
- There's also a `help commands` command for listing all the command modules so it's easier to play around with the existing commands I guess