### PR TITLE
Simple argument parser variable substitution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 # Dependencies
 node_modules
 
-
 # DS Store binary
 *.DS_Store
 
 # Source maps (I guess we can include it later? But the file looks fat to me lol)
 build/*.map
 
-# Storage for Node from src/utils/storage.js
-node-storage
+# Bot token file (when running in Node)
+data/token.txt
+
+# Bot data (when running in Node)
+data/data.json

--- a/README.md
+++ b/README.md
@@ -1,9 +1,36 @@
 # HarVM
 Bot
 
+## To run
+
 You'll need [Node](https://nodejs.org/).
 
 ```sh
+# Get Rollup
 npm install -g rollup
-npm build
+
+# Get other dependencies
+npm install
 ```
+
+You can run the bot in Node:
+
+```sh
+# Store bot token in data/token.txt
+echo "your token here" > data/token.txt
+
+# Start bot in Node
+npm start
+```
+
+Or you can run it in your browser:
+
+```sh
+# Build once
+npm run build
+
+# For development: automatically build when a file is changed
+npm run watch
+```
+
+And open index.html in your browser in localhost. For Node, you can use [http-server](https://www.npmjs.com/package/http-server).

--- a/data/token.example.txt
+++ b/data/token.example.txt
@@ -1,0 +1,1 @@
+6qrZcUqja7812RVdnEKjpzOL4CvHBFG

--- a/src/utils/parsers.js
+++ b/src/utils/parsers.js
@@ -140,7 +140,7 @@ class SimpleArgumentParser extends Parser {
 		// of "words" (see the function description) or strings.
 		const tokens = [...unparsedArgs.matchAll(/("(?:[^"\\]|\\.)*")|[^\s]+/g)]
 			// Parse strings using JSON.parse.
-			.map(match => match[1] ? JSON.parse(match[1]) : match[0])
+			.map(match => SimpleArgumentParser.substituteEnv(env, match[1] ? JSON.parse(match[1]) : match[0]))
 
 		const invalidations = []
 
@@ -224,6 +224,18 @@ class SimpleArgumentParser extends Parser {
 		}
 		// The tokens didn't match any of the possible parsings, so it failed.
 		throw new ParserError(invalidations.join('\n'))
+	}
+
+	static _envSubstitutor = /\$\$|\$\((\w+)\)|\$([^(])/g
+
+	static substituteEnv (env, token) {
+		return token.replace(SimpleArgumentParser._envSubstitutor, (match, varName, char) => {
+			if (varName) {
+				return env.get(varName)
+			} else {
+				return char || '$'
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Resolves #10 

A command like

> batch
> ```py
> data set 3 -> a
> testing simple "three = $(a)" "I have $1 dollars. $$(eee) $$$(a)" keyboard
> ```

Will output

```json
{
  "type": "main",
  "required": "three = 3",
  "optional": "I have 1 dollars. $(eee) $3"
}
```

Like the Bash-like parser, `$(varName)` will substitute itself with the value of `varName`. To escape it, do `$$`. (This differs from the Bash-like parser which would instead have `\$`, but since the simple parser uses `JSON.parse`, too many backslashes would be required to escape a `$`.)