### PR TITLE
Fixed syntax of help response.

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -53,7 +53,7 @@ command.parser = new SimpleArgumentParser({
 }, {}, 'Gives more information about the given command.')
 
 function main({ reply }){
-	reply('Usage: help [commands|command]')
+	reply('Usage: help commands|command ...')
 }
 
 export {


### PR DESCRIPTION
That's basically all I did. Brackets mean optional, however, the commands|command isn't optional. Also, angled brackets mean substitute it for the actual value, however, this command wants the word "commands" or the word "command," not any command at that argument.